### PR TITLE
tvOS support

### DIFF
--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3"
 log = "0.4"
 # Disable default features since the `rustls` variant requires it. We re-enable `default` in our
 # `default` build configuration - see the [features] below.
-rusoto_core = { git = "https://github.com/sameer/rusoto.git", rev = "0346b41b414d036eb54cdf64781a17ba4b1a8ba4", optional = true, default_features = false }
-rusoto_dynamodb = { git = "https://github.com/sameer/rusoto.git", rev = "0346b41b414d036eb54cdf64781a17ba4b1a8ba4", version = "0.48", optional = true, default_features = false }
+rusoto_core = { git = "https://github.com/kitplummer/rusoto.git", rev = "99735c384d01099d565a8818edf395dbd25308d0", optional = true, default_features = false }
+rusoto_dynamodb = { git = "https://github.com/kitplummer/rusoto.git", rev = "99735c384d01099d565a8818edf395dbd25308d0", optional = true, default_features = false }
 uuid = { version = "1.1.2", features = ["v4"], optional = true }
 chrono = { version = "0.4", optional = true }
 


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:
- I updated the version of rusoto to use an internal fork that provides tvOS support by updating hyper-rustls and hyper-tls

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

#### How did you verify your change:
- `cargo +nightly build -Z build-std --lib --target aarch64-apple-tvos -v` and then checked the 

#### What (if anything) would need to be called out in the CHANGELOG for the next release: